### PR TITLE
Add comprehensive KMS keys configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 # Makefile for Terraform operations
-.PHONY: help init plan apply destroy validate format check clean
+.PHONY: help init plan apply destroy validate format check clean plan-secrets plan-kms
 
 # Default target
 help:
 	@echo "Available targets:"
-	@echo "  init      - Initialize Terraform"
-	@echo "  validate  - Validate Terraform configuration"
-	@echo "  format    - Format Terraform files"
-	@echo "  plan      - Create Terraform execution plan"
-	@echo "  apply     - Apply Terraform configuration"
-	@echo "  destroy   - Destroy Terraform-managed infrastructure"
-	@echo "  check     - Run validation and formatting checks"
-	@echo "  clean     - Clean Terraform cache and state backup files"
+	@echo "  init        - Initialize Terraform"
+	@echo "  validate    - Validate Terraform configuration"
+	@echo "  format      - Format Terraform files"
+	@echo "  plan        - Create Terraform execution plan"
+	@echo "  plan-secrets - Plan only Secrets Manager resources"
+	@echo "  plan-kms    - Plan only KMS resources"
+	@echo "  apply       - Apply Terraform configuration"
+	@echo "  destroy     - Destroy Terraform-managed infrastructure"
+	@echo "  check       - Run validation and formatting checks"
+	@echo "  clean       - Clean Terraform cache and state backup files"
 
 # Initialize Terraform
 init:
@@ -57,6 +59,13 @@ clean:
 
 # Development workflow
 dev-setup: init validate format plan
+
+# Plan specific resource types
+plan-secrets:
+	terraform plan -target="aws_secretsmanager_secret.secrets"
+
+plan-kms:
+	terraform plan -target="aws_kms_key.keys" -target="aws_kms_alias.key_aliases"
 
 # Production deployment workflow
 prod-deploy: init validate plan

--- a/TERRAFORM_README.md
+++ b/TERRAFORM_README.md
@@ -1,6 +1,6 @@
-# AWS Secrets Manager Terraform Configuration
+# AWS Secrets Manager & KMS Keys Terraform Configuration
 
-This Terraform configuration manages AWS Secrets Manager secrets for the Snowflake Demo project. It creates and manages 25 different secrets used across various services and environments.
+This Terraform configuration manages AWS Secrets Manager secrets and KMS keys for the Snowflake Demo project. It creates and manages 25 different secrets and 7 KMS keys used across various services and environments.
 
 ## 📁 File Structure
 
@@ -8,6 +8,9 @@ This Terraform configuration manages AWS Secrets Manager secrets for the Snowfla
 ├── providers.tf          # Terraform and AWS provider configuration
 ├── variables.tf          # Variable definitions and defaults
 ├── secrets_manager.tf    # Main secrets configuration
+├── kms_keys.tf           # KMS keys configuration
+├── terraform.tfvars.example # Example configuration file
+├── Makefile              # Common Terraform operations
 └── TERRAFORM_README.md   # This documentation
 ```
 
@@ -51,6 +54,21 @@ This Terraform configuration manages AWS Secrets Manager secrets for the Snowfla
 - `AmazonSageMaker-3f3c404d1fdf49d29b82332c9ea62032` - SageMaker credentials
 - `imo-client` - IMO client credentials
 - `healthy-places` - Healthy Places application credentials
+
+## 🔑 KMS Keys Managed
+
+### MWAA (Managed Workflows for Apache Airflow) Keys
+- `shc-dts-nonprod-mwaa` - SHC DTS non-production MWAA encryption
+- `shc-dts-test-mwaa` - SHC DTS test MWAA encryption
+- `shc-dts-prod-mwaa` - SHC DTS production MWAA encryption
+
+### EKS Cluster Keys
+- `cmk-eks-tawseksprod-cluster` - EKS production cluster encryption
+- `cmk-eks-tawseksdev-cluster` - EKS development cluster encryption
+- `cmk-eks-tawseksqa-cluster` - EKS QA cluster encryption
+
+### SageMaker Keys
+- `shc-ea-sagemaker-key100` - SHC EA SageMaker service encryption
 
 ## 🚀 Usage
 

--- a/kms_keys.tf
+++ b/kms_keys.tf
@@ -1,0 +1,259 @@
+# AWS KMS Keys Configuration
+# This file contains all the KMS keys used across different environments and services
+
+# Local values for KMS key configurations
+locals {
+  # KMS key configurations with their metadata
+  kms_keys_config = {
+    # MWAA (Managed Workflows for Apache Airflow) Keys
+    "shc-dts-nonprod-mwaa" = {
+      description = "KMS key for SHC DTS non-production MWAA environment encryption"
+      tags = {
+        Environment  = "nonprod"
+        Service      = "mwaa"
+        Organization = "shc"
+        Team         = "dts"
+        Purpose      = "airflow-encryption"
+      }
+    }
+
+    "shc-dts-test-mwaa" = {
+      description = "KMS key for SHC DTS test MWAA environment encryption"
+      tags = {
+        Environment  = "test"
+        Service      = "mwaa"
+        Organization = "shc"
+        Team         = "dts"
+        Purpose      = "airflow-encryption"
+      }
+    }
+
+    "shc-dts-prod-mwaa" = {
+      description = "KMS key for SHC DTS production MWAA environment encryption"
+      tags = {
+        Environment  = "production"
+        Service      = "mwaa"
+        Organization = "shc"
+        Team         = "dts"
+        Purpose      = "airflow-encryption"
+      }
+    }
+
+    # EKS Cluster Keys
+    "cmk-eks-tawseksprod-cluster" = {
+      description = "Customer Managed Key for EKS production cluster encryption"
+      tags = {
+        Environment = "production"
+        Service     = "eks"
+        Cluster     = "tawseksprod"
+        Purpose     = "cluster-encryption"
+      }
+    }
+
+    "cmk-eks-tawseksdev-cluster" = {
+      description = "Customer Managed Key for EKS development cluster encryption"
+      tags = {
+        Environment = "development"
+        Service     = "eks"
+        Cluster     = "tawseksdev"
+        Purpose     = "cluster-encryption"
+      }
+    }
+
+    "cmk-eks-tawseksqa-cluster" = {
+      description = "Customer Managed Key for EKS QA cluster encryption"
+      tags = {
+        Environment = "qa"
+        Service     = "eks"
+        Cluster     = "tawseksqa"
+        Purpose     = "cluster-encryption"
+      }
+    }
+
+    # SageMaker Key
+    "shc-ea-sagemaker-key100" = {
+      description = "KMS key for SHC EA SageMaker service encryption"
+      tags = {
+        Environment  = "production"
+        Service      = "sagemaker"
+        Organization = "shc"
+        Team         = "ea"
+        Purpose      = "ml-encryption"
+        KeyVersion   = "100"
+      }
+    }
+  }
+
+  # KMS key policy for different services
+  mwaa_key_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow MWAA Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "airflow.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${var.aws_region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  eks_key_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow EKS Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  sagemaker_key_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow SageMaker Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Data source to get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# Create all KMS keys using for_each for better maintainability
+resource "aws_kms_key" "keys" {
+  for_each = local.kms_keys_config
+
+  description              = each.value.description
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  deletion_window_in_days  = var.kms_deletion_window_in_days
+  enable_key_rotation      = var.enable_kms_key_rotation
+
+  # Set policy based on service type
+  policy = contains(keys(each.value.tags), "Service") ? (
+    each.value.tags.Service == "mwaa" ? local.mwaa_key_policy :
+    each.value.tags.Service == "eks" ? local.eks_key_policy :
+    each.value.tags.Service == "sagemaker" ? local.sagemaker_key_policy :
+    null
+  ) : null
+
+  tags = merge(
+    local.base_tags,
+    each.value.tags,
+    {
+      Name = each.key
+    }
+  )
+}
+
+# Create KMS aliases for easier identification
+resource "aws_kms_alias" "key_aliases" {
+  for_each = local.kms_keys_config
+
+  name          = "alias/${each.key}"
+  target_key_id = aws_kms_key.keys[each.key].key_id
+}
+
+# KMS Key Grants (Optional - uncomment and modify as needed)
+# These provide specific permissions to services or roles
+
+/*
+# Example: Grant for MWAA service role
+resource "aws_kms_grant" "mwaa_grants" {
+  for_each = {
+    for name, config in local.kms_keys_config : name => config
+    if lookup(config.tags, "Service", "") == "mwaa"
+  }
+  
+  name              = "${each.key}-mwaa-grant"
+  key_id            = aws_kms_key.keys[each.key].key_id
+  grantee_principal = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AmazonMWAA-${each.key}-ExecutionRole"
+  
+  operations = [
+    "Decrypt",
+    "GenerateDataKey",
+    "CreateGrant",
+    "RetireGrant"
+  ]
+}
+
+# Example: Grant for EKS cluster service role
+resource "aws_kms_grant" "eks_grants" {
+  for_each = {
+    for name, config in local.kms_keys_config : name => config
+    if lookup(config.tags, "Service", "") == "eks"
+  }
+  
+  name              = "${each.key}-eks-grant"
+  key_id            = aws_kms_key.keys[each.key].key_id
+  grantee_principal = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${lookup(each.value.tags, "Cluster", "unknown")}-cluster-ServiceRole"
+  
+  operations = [
+    "Decrypt",
+    "GenerateDataKey",
+    "CreateGrant",
+    "RetireGrant"
+  ]
+}
+*/

--- a/secrets_manager.tf
+++ b/secrets_manager.tf
@@ -333,3 +333,41 @@ output "secrets_by_type" {
     lookup(config.tags, "Type", "unknown") => name...
   }
 }
+
+# KMS Key Outputs
+output "kms_key_arns" {
+  description = "ARNs of all created KMS keys"
+  value = {
+    for name, key in aws_kms_key.keys : name => key.arn
+  }
+}
+
+output "kms_key_ids" {
+  description = "IDs of all created KMS keys"
+  value = {
+    for name, key in aws_kms_key.keys : name => key.key_id
+  }
+}
+
+output "kms_aliases" {
+  description = "KMS key aliases"
+  value = {
+    for name, alias in aws_kms_alias.key_aliases : name => alias.name
+  }
+}
+
+output "kms_keys_by_service" {
+  description = "KMS keys grouped by service"
+  value = {
+    for name, config in local.kms_keys_config :
+    lookup(config.tags, "Service", "unknown") => name...
+  }
+}
+
+output "kms_keys_by_environment" {
+  description = "KMS keys grouped by environment"
+  value = {
+    for name, config in local.kms_keys_config :
+    lookup(config.tags, "Environment", "unknown") => name...
+  }
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -12,6 +12,10 @@ project_name = "snowflake_demo"
 recovery_window_in_days = 30
 enable_automatic_rotation = false
 
+# KMS key settings
+kms_deletion_window_in_days = 30
+enable_kms_key_rotation = true
+
 # Common tags applied to all resources
 common_tags = {
   Project     = "snowflake_demo"

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,24 @@ variable "enable_automatic_rotation" {
   default     = false
 }
 
+# KMS Key Variables
+variable "kms_deletion_window_in_days" {
+  description = "Number of days after which KMS key is deleted after destruction"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.kms_deletion_window_in_days >= 7 && var.kms_deletion_window_in_days <= 30
+    error_message = "KMS deletion window must be between 7 and 30 days."
+  }
+}
+
+variable "enable_kms_key_rotation" {
+  description = "Whether to enable automatic rotation for KMS keys"
+  type        = bool
+  default     = true
+}
+
 variable "common_tags" {
   description = "Common tags to apply to all secrets"
   type        = map(string)


### PR DESCRIPTION
- Add 7 KMS keys for MWAA, EKS, and SageMaker services
- Include service-specific IAM policies for each key type
- Add KMS aliases for easier key identification
- Implement configurable deletion windows and key rotation
- Add KMS-specific variables and outputs
- Update documentation and Makefile for KMS operations
- Include examples for KMS grants (commented out)

KMS Keys Added:
- shc-dts-nonprod-mwaa, shc-dts-test-mwaa, shc-dts-prod-mwaa (MWAA)
- cmk-eks-tawseksprod-cluster, cmk-eks-tawseksdev-cluster, cmk-eks-tawseksqa-cluster (EKS)
- shc-ea-sagemaker-key100 (SageMaker)

Features:
- Service-specific IAM policies for secure access
- Consistent tagging strategy across all keys
- Outputs for ARNs, IDs, aliases, and groupings
- Production-ready with security best practices